### PR TITLE
docs: add AUR package link for Arch / Manjaro users

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ https://github.com/zhuminjie/OpenSeesPy/tree/openseespy/pip
 The pip install page is at
 
 https://pypi.org/project/openseespy/
+
+## Arch Linux / Manjaro
+
+The AUR package for Arch-based systems is at
+
+https://aur.archlinux.org/packages/python-openseespy


### PR DESCRIPTION
Hi Dr. Zhu,

Due to PEP 668 externally-managed-environment restrictions on modern Arch-based Linux distributions (like Arch Linux and Manjaro), global pip installations are blocked by the system package manager. To help users bypass this and seamlessly install OpenSeesPy system-wide, I have packaged it for the Arch User Repository (AUR) under the name python-openseespy. Users can simply install it via: 
```bash
yay -S python-opensees
```
This PR adds a brief section and the AUR link to the bottom of the README, keeping the exact same minimalist formatting as your ## Pip section. Please feel free to edit or adjust before merging. 

Best regards.